### PR TITLE
Support for docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,28 @@
+FROM rust AS builder
+
+WORKDIR /src
+COPY . .
+RUN chown -R 1000:1000 /src
+
+RUN cargo build --release
+
+FROM archlinux
+
+RUN pacman -Syu --noconfirm \
+      texlive-basic \
+      texlive-latexrecommended \
+      texlive-latexextra \
+      texlive-fontsextra
+
+RUN pacman -S --noconfirm inotify-tools
+
+COPY --from=builder /src/target/release/curriculust /usr/bin/curriculust
+COPY --from=builder /src/build.sh /usr/bin/curriculust-watch
+RUN sed -i 's#cargo run --#/usr/bin/curriculust#' /usr/bin/curriculust-watch
+RUN sed -i 's#"./src/" "./resume_cv_proc_macro"##' /usr/bin/curriculust-watch
+
+WORKDIR /src
+RUN useradd -u 1000 user -M -d /src
+RUN chown -R 1000:1000 /src
+USER 1000:1000
+ENTRYPOINT ["/usr/bin/curriculust-watch"]

--- a/README.md
+++ b/README.md
@@ -71,6 +71,21 @@ Internally `build.sh` calls:
 
 For example, to build the example in the `example/` folder with the Developer CV template, the command would be `./build.sh ./example/base.yml ./build/example.tex ./template/developercv.cls`.
 
+## Dockerfile usage
+
+Docker is supported through the provided Dockerfile. It packages the main `curricust` binary and the `build.sh` script (slightly patched for docker support) under `curricust-watch`. The default entrypoint is `curricust-watch` but can be changed using the `--entrypoint` flag for docker.
+The container workdir is under /src, so just mount your cv source files unders /src and you can reference them directly.
+Practical example:
+```sh
+git clone https://github.com/Stypox/curricust
+cd curricust
+docker build . -t curricust:latest
+# this is clunky, but important, see the note below.
+mkdir out
+docker run --rm -it -v "$PWD/example:/src" -v "$PWD/template/:/src/template" curricust base.yml out/out.pdf template/developercv.cls --watch
+```
+**Note: docker support it's very limited at the current stage. It is not guaranteed to work out of the box.**
+
 
 ## Templates
 


### PR DESCRIPTION
add Dockerfile for containerization, so that we can avoiding clogging our systems with enormous latex packages.
uses two containers: `rust` for building and `archlinux` for running (with latex dependencies installed).
default entrypoint is the watcher wrapper `/usr/bin/curriculust-watch` (slightly modified version of `build.sh`) but can be changed to the pure version (`/usr/bin/curriculust`: the binary from cargo) using `--entrypoint /usr/bin/curriculust` when invoking `docker run`